### PR TITLE
Remove useless conversion found by clippy

### DIFF
--- a/src/sample/g_trapdoor/gadget_parameters.rs
+++ b/src/sample/g_trapdoor/gadget_parameters.rs
@@ -173,7 +173,6 @@ impl GadgetParametersRing {
         // [`i64`] because downstream matrices can be at most that size
         let modulus = modulus.into();
         let n = n.into();
-        let modulus = modulus.into();
         assert!(n >= Z::ONE && n <= Z::from(i64::MAX));
 
         let base = Z::from(2);


### PR DESCRIPTION
When merging, a line was added twice, this was detected by clippy and gets removed here.
