### PR TITLE
IND-CCS from IBE

### DIFF
--- a/benches/pfdh.rs
+++ b/benches/pfdh.rs
@@ -7,11 +7,11 @@
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
 use criterion::{criterion_group, Criterion};
-use qfall_crypto::construction::signature::{pfdh::Pfdh, SignatureScheme};
+use qfall_crypto::construction::signature::{pfdh::PFDH, SignatureScheme};
 
 /// Performs a full instantiation with an additional signing and verifying of a signature.
 fn pfdh_cycle(n: i64) {
-    let mut pfdh = Pfdh::init_gpv(n, 113, 17, 128);
+    let mut pfdh = PFDH::init_gpv(n, 113, 17, 128);
 
     let m = "Hello World!";
 
@@ -46,7 +46,7 @@ fn bench_pfdh_full_cycle(c: &mut Criterion) {
 /// benchmark name. The `\ ` is used to escape the space, alternatively,
 /// quotation marks can be used.
 fn bench_pfdh_signature(c: &mut Criterion) {
-    let mut pfdh = Pfdh::init_gpv(8, 113, 17, 128);
+    let mut pfdh = PFDH::init_gpv(8, 113, 17, 128);
 
     let m = "Hello World!";
 

--- a/src/construction/identity_based_encryption.rs
+++ b/src/construction/identity_based_encryption.rs
@@ -25,7 +25,7 @@ pub use dual_regev_ibe::DualRegevIBE;
 
 use qfall_math::integer::Z;
 
-pub trait IBE {
+pub trait IdentityBasedEncryption {
     type MasterPublicKey;
     type MasterSecretKey;
     type SecretKey;

--- a/src/construction/identity_based_encryption/dual_regev_ibe.rs
+++ b/src/construction/identity_based_encryption/dual_regev_ibe.rs
@@ -10,7 +10,7 @@
 //! identity based public key encryption scheme. The encryption scheme is based
 //! on [`DualRegevIBE`].
 
-use super::IBE;
+use super::IdentityBasedEncryption;
 use crate::{
     construction::{
         hash::sha256::hash_to_mat_zq_sha256,
@@ -275,7 +275,7 @@ impl Default for DualRegevIBE {
     }
 }
 
-impl IBE for DualRegevIBE {
+impl IdentityBasedEncryption for DualRegevIBE {
     type Cipher = MatZq;
     type MasterPublicKey = MatZq;
     type MasterSecretKey = (MatZ, MatQ);
@@ -427,7 +427,7 @@ impl IBE for DualRegevIBE {
 #[cfg(test)]
 mod test_dual_regev_ibe {
     use super::DualRegevIBE;
-    use crate::construction::identity_based_encryption::IBE;
+    use crate::construction::identity_based_encryption::IdentityBasedEncryption;
     use qfall_math::integer::Z;
 
     /// Checks whether `new` is available for types implementing [`Into<Z>`].

--- a/src/construction/identity_based_encryption/dual_regev_ibe.rs
+++ b/src/construction/identity_based_encryption/dual_regev_ibe.rs
@@ -29,7 +29,7 @@ use qfall_math::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// This struct manages and stores the public parameters of a [`IBE`]
+/// This struct manages and stores the public parameters of a [`IdentityBasedEncryption`]
 /// public key encryption instance based on [\[1\]](<index.html#:~:text=[1]>).
 ///
 /// Attributes:
@@ -41,7 +41,7 @@ use std::collections::HashMap;
 ///
 /// # Examples
 /// ```
-/// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IBE};
+/// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IdentityBasedEncryption};
 /// use qfall_math::integer::Z;
 /// // setup public parameters and key pair
 /// let mut ibe = DualRegevIBE::default();
@@ -62,8 +62,8 @@ use std::collections::HashMap;
 /// ```
 #[derive(Serialize, Deserialize)]
 pub struct DualRegevIBE {
-    dual_regev: DualRegev,
-    psf: PSFGPV,
+    pub dual_regev: DualRegev,
+    pub psf: PSFGPV,
     storage: HashMap<String, MatZ>,
 }
 
@@ -293,7 +293,7 @@ impl IdentityBasedEncryption for DualRegevIBE {
     ///
     /// # Examples
     /// ```
-    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IBE};
+    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IdentityBasedEncryption};
     /// let ibe = DualRegevIBE::default();
     ///
     /// let (pk, sk) = ibe.setup();
@@ -317,7 +317,7 @@ impl IdentityBasedEncryption for DualRegevIBE {
     ///
     /// # Examples
     /// ```
-    /// use qfall_crypto::construction::identity_based_encryption::{IBE, DualRegevIBE};
+    /// use qfall_crypto::construction::identity_based_encryption::{IdentityBasedEncryption, DualRegevIBE};
     /// let mut ibe = DualRegevIBE::default();
     /// let (master_pk, master_sk) = ibe.setup();
     ///
@@ -368,7 +368,7 @@ impl IdentityBasedEncryption for DualRegevIBE {
     ///
     /// # Examples
     /// ```
-    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IBE};
+    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IdentityBasedEncryption};
     /// let ibe = DualRegevIBE::default();
     /// let (pk, sk) = ibe.setup();
     ///
@@ -400,7 +400,7 @@ impl IdentityBasedEncryption for DualRegevIBE {
     ///
     /// # Examples
     /// ```
-    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IBE};
+    /// use qfall_crypto::construction::identity_based_encryption::{DualRegevIBE, IdentityBasedEncryption};
     /// use qfall_math::integer::Z;
     /// // setup public parameters and key pair
     /// let mut ibe = DualRegevIBE::default();

--- a/src/construction/pk_encryption.rs
+++ b/src/construction/pk_encryption.rs
@@ -27,13 +27,19 @@
 //! Better key sizes (and attacks) for LWE-based encryption.
 //! In: Topics in Cryptology -  RSA Conference 2011, Springer.
 //! <https://eprint.iacr.org/2010/613.pdf>
+//! - \[5\] Canetti, R., Halevi, S., and Katz, J. (2004).
+//! Chosen-ciphertext security from identity-based encryption.
+//! In: Advances in Cryptology - EUROCRYPT 2004.
+//! <https://link.springer.com/content/pdf/10.1007/b97182.pdf>
 
+mod ccs_from_ibe;
 mod dual_regev;
 mod dual_regev_discrete_gauss;
 mod lpr;
 mod regev;
 mod regev_discrete_gauss;
 mod ring_lpr;
+pub use ccs_from_ibe::CCSfromIBE;
 pub use dual_regev::DualRegev;
 pub use dual_regev_discrete_gauss::DualRegevWithDiscreteGaussianRegularity;
 pub use lpr::LPR;

--- a/src/construction/pk_encryption.rs
+++ b/src/construction/pk_encryption.rs
@@ -80,6 +80,37 @@ pub trait PKEncryption {
     fn dec(&self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z;
 }
 
+/// This trait just exists s.t. we can pass `self` in as mutable for more advanced constructions, which use a storage.
+/// Otherwise, it does exactly the same as [`PKEncryption`].
+pub trait PKEncryptionMut {
+    type PublicKey;
+    type SecretKey;
+    type Cipher;
+
+    /// Generates a public key pair `(pk, sk)` suitable for the specific scheme.
+    ///
+    /// Returns a tuple `(pk, sk)` consisting of [`Self::PublicKey`] and [`Self::SecretKey`].
+    fn gen(&mut self) -> (Self::PublicKey, Self::SecretKey);
+
+    /// Encrypts the provided `message` using the public key `pk`.
+    ///
+    /// Parameters:
+    /// - `pk`: specifies the public key used for encryption
+    /// - `message`: specifies the message to be encrypted
+    ///
+    /// Returns the encryption of `message` as a [`Self::Cipher`] instance.
+    fn enc(&mut self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher;
+
+    /// Decrypts the provided `cipher` using the secret key `sk`.
+    ///
+    /// Parameters:
+    /// - `sk`: specifies the secret key used for decryption
+    /// - `cipher`: specifies the ciphertext to be decrypted
+    ///
+    /// Returns the decryption of `cipher` as a [`Z`] instance.
+    fn dec(&mut self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z;
+}
+
 /// This trait generically implements multi-bit encryption
 /// for any scheme implementing the [`PKEncryption`] trait.
 ///

--- a/src/construction/pk_encryption/ccs_from_ibe.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe.rs
@@ -1,0 +1,64 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-crypto.
+//
+// qFALL-crypto is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! This module contains an implementation of the IND-CCA secure
+//! public key encryption scheme constructed via an IBE scheme and a signature.
+
+use super::PKEncryption;
+use crate::construction::{
+    identity_based_encryption::IdentityBasedEncryption, signature::SignatureScheme,
+};
+use qfall_math::integer::Z;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct CCSfromIBE<IBE: IdentityBasedEncryption, Signature: SignatureScheme> {
+    ibe: IBE,
+    signature: Signature,
+}
+
+impl<IBE, Signature> PKEncryption for CCSfromIBE<IBE, Signature>
+where
+    IBE: IdentityBasedEncryption,
+    Signature: SignatureScheme,
+{
+    type Cipher = (
+        SignatureScheme::PublicKey,
+        IdentityBasedEncryption::Cipher,
+        SignatureScheme::Signature,
+    );
+    type PublicKey = IdentityBasedEncryption::MasterPublicKey;
+    type SecretKey = (
+        IdentityBasedEncryption::MasterPublicKey,
+        IdentityBasedEncryption::MasterSecretKey,
+    );
+
+    fn gen(&self) -> (Self::PublicKey, Self::SecretKey) {
+        let (pk, sk) = self.ibe.setup();
+        (pk, (pk, sk))
+    }
+
+    fn enc(&self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher {
+        let message = message.into().modulo(2).unwrap();
+
+        let (sign_key, vrfy_key) = self.signature.gen();
+
+        let c = self.ibe.enc(pk, vrfy_key, message);
+        let sigma = self.signature.sign(c.to_string(), sk, pk);
+        (vrfy_key, c, sigma)
+    }
+
+    fn dec(&self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
+        if !self.signature.vfy(cipher.1, cipher.2, cipher.0) {
+            return Z::MINUS_ONE;
+        }
+
+        let secret = self.ibe.extract(sk.0, sk.1, cipher.0);
+        self.ibe.dec(secret, cipher.1)
+    }
+}

--- a/src/construction/pk_encryption/ccs_from_ibe.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe.rs
@@ -6,59 +6,122 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This module contains an implementation of the IND-CCA secure
-//! public key encryption scheme constructed via an IBE scheme and a signature.
+//! This module contains a general implementation of an IND-CCA secure
+//! public key encryption scheme constructed
+//! via an [`IdentityBasedEncryption`] scheme and a [`SignatureScheme`].
 
-use super::PKEncryption;
+use super::PKEncryptionMut;
 use crate::construction::{
     identity_based_encryption::IdentityBasedEncryption, signature::SignatureScheme,
 };
 use qfall_math::integer::Z;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-pub struct CCSfromIBE<IBE: IdentityBasedEncryption, Signature: SignatureScheme> {
-    ibe: IBE,
-    signature: Signature,
+pub mod dual_regev_ibe_pfdh;
+
+/// This struct manages and stores the public parameters of an [`CCSfromIBE`]
+/// public key encryption construction based on [\[5\]](<index.html#:~:text=[5]>).
+///
+/// Attributes:
+/// - `ibe`: specifies the IBE scheme used in this construction
+/// - `signature`: specifies the signature scheme used in this construction
+///
+/// # Examples
+/// ```
+/// todo!();
+/// ```
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CCSfromIBE<IBE: IdentityBasedEncryption, Signature: SignatureScheme>
+where
+    IBE::Cipher: ToString,
+{
+    pub ibe: IBE,
+    pub signature: Signature,
 }
 
-impl<IBE, Signature> PKEncryption for CCSfromIBE<IBE, Signature>
+impl<IBE, Signature> PKEncryptionMut for CCSfromIBE<IBE, Signature>
 where
     IBE: IdentityBasedEncryption,
     Signature: SignatureScheme,
+    IBE::Cipher: ToString,
+    IBE::MasterPublicKey: Clone,
+    Signature::PublicKey: Into<IBE::Identity> + Clone,
 {
-    type Cipher = (
-        SignatureScheme::PublicKey,
-        IdentityBasedEncryption::Cipher,
-        SignatureScheme::Signature,
-    );
-    type PublicKey = IdentityBasedEncryption::MasterPublicKey;
-    type SecretKey = (
-        IdentityBasedEncryption::MasterPublicKey,
-        IdentityBasedEncryption::MasterSecretKey,
-    );
+    type Cipher = (Signature::PublicKey, IBE::Cipher, Signature::Signature);
+    type PublicKey = IBE::MasterPublicKey;
+    type SecretKey = (IBE::MasterPublicKey, IBE::MasterSecretKey);
 
-    fn gen(&self) -> (Self::PublicKey, Self::SecretKey) {
+    /// Generates a (pk, sk) pair for the CCS construction
+    /// by following these steps:
+    /// - (mpk, msk) = ibe.setup()
+    ///
+    /// Then, `pk = mpk` and `sk = (mpk, msk)` are returned.
+    ///
+    /// # Examples
+    /// ```
+    /// todo!();
+    /// ```
+    fn gen(&mut self) -> (Self::PublicKey, Self::SecretKey) {
         let (pk, sk) = self.ibe.setup();
-        (pk, (pk, sk))
+        (pk.clone(), (pk, sk))
     }
 
-    fn enc(&self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher {
-        let message = message.into().modulo(2).unwrap();
+    /// Generates an encryption of `message mod 2` for the provided public key by following these steps:
+    /// - (vrfy_key, sign_key) = signature.gen()
+    /// - c = ibe.enc(mpk, vrfy_key, message), i.e. encrypt `message mod 2` with respect to identity `vrfy_key`
+    /// - sigma = signature.sign(c, sign_key, vrfy_key), i.e. sign message `c`
+    ///
+    /// Then, the ciphertext `(vrfy_key, c, sigma)` is returned.
+    ///
+    /// Parameters:
+    /// - `pk`: specifies the public key `pk = A`
+    /// - `message`: specifies the message that should be encrypted
+    ///
+    /// Returns a cipher consisting of a tuple `cipher = (vrfy_key, c, sigma)`.
+    ///
+    /// # Examples
+    /// ```
+    /// todo!();
+    /// ```
+    fn enc(&mut self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher {
+        let message = message.into().modulo(2);
 
-        let (sign_key, vrfy_key) = self.signature.gen();
+        let (vrfy_key, sign_key) = self.signature.gen();
 
-        let c = self.ibe.enc(pk, vrfy_key, message);
-        let sigma = self.signature.sign(c.to_string(), sk, pk);
+        let c = self.ibe.enc(pk, &vrfy_key.clone().into(), message);
+        let sigma = self.signature.sign(c.to_string(), &sign_key, &vrfy_key);
         (vrfy_key, c, sigma)
     }
 
-    fn dec(&self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
-        if !self.signature.vfy(cipher.1, cipher.2, cipher.0) {
+    /// Decrypts the provided `cipher` using the secret key `sk` by following these steps:
+    /// - if signature.vrfy(c, sigma, vrfy_key) is not successful, output -1, otherwise proceed
+    /// - secret_key = ibe.extract(mpk, msk, vrfy_key), i.e. extract the secret key for identity `vrfy_key`
+    /// - ibe.dec(secret_key, c)
+    ///
+    /// Then, the resulting decryption is returned.
+    ///
+    /// Parameters:
+    /// - `sk`: specifies the secret key `sk = (mpk, msk)`
+    /// - `cipher`: specifies the cipher containing `cipher = (vrfy_key, c, sigma)`
+    ///
+    /// Returns the decryption of `cipher` as a [`Z`] instance.
+    ///
+    /// # Examples
+    /// ```
+    /// todo!();
+    /// ```
+    fn dec(&mut self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
+        if !self
+            .signature
+            .vfy(cipher.1.to_string(), &cipher.2, &cipher.0)
+        {
             return Z::MINUS_ONE;
         }
 
-        let secret = self.ibe.extract(sk.0, sk.1, cipher.0);
-        self.ibe.dec(secret, cipher.1)
+        // as this secret key is never computed or seen by anybody else than the owner of the master secret key,
+        // it does not hurt the security premises of the scheme to ignore the storage of the IBE's key extraction,
+        // which is required in order to not make `self` mutable accross all public key encryption schemes
+        let secret = self.ibe.extract(&sk.0, &sk.1, &cipher.0.clone().into());
+        self.ibe.dec(&secret, &cipher.1)
     }
 }

--- a/src/construction/pk_encryption/ccs_from_ibe.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe.rs
@@ -77,9 +77,9 @@ where
         (pk.clone(), (pk, sk))
     }
 
-    /// Generates an encryption of `message mod 2` for the provided public key by following these steps:
+    /// Generates an encryption of `message` for the provided public key by following these steps:
     /// - (vrfy_key, sign_key) = signature.gen()
-    /// - c = ibe.enc(mpk, vrfy_key, message), i.e. encrypt `message mod 2` with respect to identity `vrfy_key`
+    /// - c = ibe.enc(mpk, vrfy_key, message), i.e. encrypt `message` with respect to identity `vrfy_key`
     /// - sigma = signature.sign(c, sign_key, vrfy_key), i.e. sign message `c`
     ///
     /// Then, the ciphertext `(vrfy_key, c, sigma)` is returned.
@@ -99,8 +99,6 @@ where
     /// let cipher = scheme.enc(&pk, 1);
     /// ```
     fn enc(&mut self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher {
-        let message = message.into().modulo(2);
-
         let (vrfy_key, sign_key) = self.signature.gen();
 
         let c = self.ibe.enc(pk, &vrfy_key.clone().into(), message);
@@ -141,9 +139,6 @@ where
             return Z::MINUS_ONE;
         }
 
-        // as this secret key is never computed or seen by anybody else than the owner of the master secret key,
-        // it does not hurt the security premises of the scheme to ignore the storage of the IBE's key extraction,
-        // which is required in order to not make `self` mutable accross all public key encryption schemes
         let secret = self.ibe.extract(&sk.0, &sk.1, &cipher.0.clone().into());
         self.ibe.dec(&secret, &cipher.1)
     }

--- a/src/construction/pk_encryption/ccs_from_ibe.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe.rs
@@ -28,7 +28,15 @@ pub mod dual_regev_ibe_pfdh;
 ///
 /// # Examples
 /// ```
-/// todo!();
+/// use qfall_crypto::construction::pk_encryption::{CCSfromIBE, PKEncryptionMut};
+/// use qfall_math::integer::Z;
+/// let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+///
+/// let (pk, sk) = scheme.gen();
+/// let cipher = scheme.enc(&pk, 0);
+/// let m = scheme.dec(&sk, &cipher);
+///
+/// assert_eq!(Z::ZERO, m);
 /// ```
 #[derive(Serialize, Deserialize, Clone)]
 pub struct CCSfromIBE<IBE: IdentityBasedEncryption, Signature: SignatureScheme>
@@ -59,7 +67,10 @@ where
     ///
     /// # Examples
     /// ```
-    /// todo!();
+    /// use qfall_crypto::construction::pk_encryption::{CCSfromIBE, PKEncryptionMut};
+    /// let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+    ///
+    /// let (pk, sk) = scheme.gen();
     /// ```
     fn gen(&mut self) -> (Self::PublicKey, Self::SecretKey) {
         let (pk, sk) = self.ibe.setup();
@@ -81,7 +92,11 @@ where
     ///
     /// # Examples
     /// ```
-    /// todo!();
+    /// use qfall_crypto::construction::pk_encryption::{CCSfromIBE, PKEncryptionMut};
+    /// let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+    ///
+    /// let (pk, sk) = scheme.gen();
+    /// let cipher = scheme.enc(&pk, 1);
     /// ```
     fn enc(&mut self, pk: &Self::PublicKey, message: impl Into<Z>) -> Self::Cipher {
         let message = message.into().modulo(2);
@@ -108,7 +123,15 @@ where
     ///
     /// # Examples
     /// ```
-    /// todo!();
+    /// use qfall_crypto::construction::pk_encryption::{CCSfromIBE, PKEncryptionMut};
+    /// use qfall_math::integer::Z;
+    /// let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+    ///
+    /// let (pk, sk) = scheme.gen();
+    /// let cipher = scheme.enc(&pk, 1);
+    /// let m = scheme.dec(&sk, &cipher);
+    ///
+    /// assert_eq!(Z::ONE, m);
     /// ```
     fn dec(&mut self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
         if !self

--- a/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
@@ -48,7 +48,7 @@ impl CCSfromIBE<DualRegevIBE, PFDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
     pub fn init_dr_pfdh(
         n: impl Into<Z>, // security parameter
         modulus: impl Into<Modulus>,
-        randomness_length: impl Into<Z>, // added for to the message before signing
+        randomness_length: impl Into<Z>, // added to the message before signing
         r: impl Into<Q>,                 // gaussian parameter for PSF
         alpha: impl Into<Q>,             // gaussian parameter for Dual Regev Encryption
     ) -> Self {

--- a/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
@@ -7,12 +7,12 @@
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
 //! A classical implementation of the [`CCSfromIBE`] scheme using
-//! the [`DualRegevIBE`] and [`Pfdh`].
+//! the [`DualRegevIBE`] and [`PFDH`].
 
 use super::CCSfromIBE;
 use crate::{
     construction::{
-        hash::sha256::HashMatZq, identity_based_encryption::DualRegevIBE, signature::pfdh::Pfdh,
+        hash::sha256::HashMatZq, identity_based_encryption::DualRegevIBE, signature::pfdh::PFDH,
     },
     primitive::psf::gpv::PSFGPV,
 };
@@ -22,13 +22,13 @@ use qfall_math::{
     rational::{MatQ, Q},
 };
 
-impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>> {
-    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`Pfdh`] signature.
+impl CCSfromIBE<DualRegevIBE, PFDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>> {
+    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`PFDH`] signature.
     ///
     /// Parameters:
     /// - `n`: specifies the security parameter
     /// - `modulus`: specifies the modulus
-    /// - `r`: specifies the Gaussian parameter used for the [`PSFGPV`] for the [`Pfdh`]
+    /// - `r`: specifies the Gaussian parameter used for the [`PSFGPV`] for the [`PFDH`]
     /// - `randomness_length`: specifies the number of bits added to the message before signing
     /// - `alpha`: specifies the Gaussian parameter used for encryption in
     /// [`DualRegev`](crate::construction::pk_encryption::DualRegev) in the [`DualRegevIBE`]
@@ -57,7 +57,7 @@ impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
         let r = r.into();
 
         let dr_ibe = DualRegevIBE::new(&n, &modulus, &r, alpha);
-        let pfdh = Pfdh::init_gpv(n, modulus, r, randomness_length);
+        let pfdh = PFDH::init_gpv(n, modulus, r, randomness_length);
 
         Self {
             ibe: dr_ibe,
@@ -65,7 +65,7 @@ impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
         }
     }
 
-    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`Pfdh`] signature
+    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`PFDH`] signature
     /// from a given `n > 0`.
     ///
     /// Parameters:
@@ -91,7 +91,7 @@ impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
         );
 
         let ibe = DualRegevIBE::new_from_n(&n);
-        let pfdh = Pfdh::init_gpv(&n, &ibe.dual_regev.q, &ibe.psf.s, &n);
+        let pfdh = PFDH::init_gpv(&n, &ibe.dual_regev.q, &ibe.psf.s, &n);
 
         Self {
             ibe,

--- a/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
@@ -1,0 +1,134 @@
+// Copyright © 2023 Niklas Siemer
+//
+// This file is part of qFALL-crypto.
+//
+// qFALL-crypto is free software: you can redistribute it and/or modify it under
+// the terms of the Mozilla Public License Version 2.0 as published by the
+// Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
+
+//! A classical implementation of the [`CCSfromIBE`] scheme using
+//! the [`DualRegevIBE`] and [`Pfdh`].
+
+use super::CCSfromIBE;
+use crate::{
+    construction::{
+        hash::sha256::HashMatZq, identity_based_encryption::DualRegevIBE, signature::pfdh::Pfdh,
+    },
+    primitive::psf::gpv::PSFGPV,
+};
+use qfall_math::{
+    integer::{MatZ, Z},
+    integer_mod_q::{MatZq, Modulus},
+    rational::{MatQ, Q},
+};
+
+impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>> {
+    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`Pfdh`] signature.
+    ///
+    /// Parameters:
+    /// - `n`: specifies the security parameter
+    /// - `modulus`: specifies the modulus
+    /// - `r`: specifies the Gaussian parameter used for the [`PSFGPV`] for the [`Pfdh`]
+    /// - `randomness_length`: specifies the number of bits added to the message before signing
+    /// - `alpha`: specifies the Gaussian parameter used for encryption in
+    /// [`DualRegev`](crate::construction::pk_encryption::DualRegev) in the [`DualRegevIBE`]
+    ///
+    /// Returns an explicit implementation of an IND-CCA-secure public key encryption scheme.
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_crypto::construction::pk_encryption::CCSfromIBE;
+    ///
+    /// let mut scheme = CCSfromIBE::init_dr_pfdh(4, 13933, 4, 10.77, 0.0021);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `modulus <= 1`.
+    /// - if `n < 1`.
+    pub fn init_dr_pfdh(
+        n: impl Into<Z>, // security parameter
+        modulus: impl Into<Modulus>,
+        randomness_length: impl Into<Z>, // added for to the message before signing
+        r: impl Into<Q>,                 // gaussian parameter for PSF
+        alpha: impl Into<Q>,             // gaussian parameter for Dual Regev Encryption
+    ) -> Self {
+        let n = n.into();
+        let modulus = modulus.into();
+        let r = r.into();
+
+        let dr_ibe = DualRegevIBE::new(&n, &modulus, &r, alpha);
+        let pfdh = Pfdh::init_gpv(n, modulus, r, randomness_length);
+
+        Self {
+            ibe: dr_ibe,
+            signature: pfdh,
+        }
+    }
+
+    /// Initializes a [`CCSfromIBE`] PK encryption scheme from a [`DualRegevIBE`] and a [`Pfdh`] signature
+    /// from a given `n > 0`.
+    ///
+    /// Parameters:
+    /// - `n`: specifies the security parameter
+    ///
+    /// Returns an explicit implementation of an IND-CCA-secure public key encryption scheme
+    /// chosen with appropriate parameters for given `n`..
+    ///
+    /// # Example
+    /// ```
+    /// use qfall_crypto::construction::pk_encryption::CCSfromIBE;
+    ///
+    /// let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+    /// ```
+    ///
+    /// # Panics ...
+    /// - if `n < 4`.
+    pub fn init_dr_pfdh_from_n(n: impl Into<Z>) -> Self {
+        let n = n.into();
+        assert!(
+            n > Z::from(3),
+            "n needs to be chosen larger than 3 for this function to work properly."
+        );
+
+        let ibe = DualRegevIBE::new_from_n(&n);
+        let pfdh = Pfdh::init_gpv(&n, &ibe.dual_regev.q, &ibe.psf.s, &n);
+
+        Self {
+            ibe,
+            signature: pfdh,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_ccs_from_ibe {
+    use super::CCSfromIBE;
+    use crate::construction::pk_encryption::PKEncryptionMut;
+    use qfall_math::integer::Z;
+
+    /// Checks whether the full-cycle of gen, enc, dec works properly
+    /// for message 0 and small n.
+    #[test]
+    fn cycle_zero() {
+        let msg = Z::ZERO;
+        let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+
+        let (pk, sk) = scheme.gen();
+        let cipher = scheme.enc(&pk, &msg);
+        let m = scheme.dec(&sk, &cipher);
+        assert_eq!(msg, m);
+    }
+
+    /// Checks whether the full-cycle of gen, enc, dec works properly
+    /// for message 1 and small n.
+    #[test]
+    fn cycle_one() {
+        let msg = Z::ONE;
+        let mut scheme = CCSfromIBE::init_dr_pfdh_from_n(4);
+
+        let (pk, sk) = scheme.gen();
+        let cipher = scheme.enc(&pk, &msg);
+        let m = scheme.dec(&sk, &cipher);
+        assert_eq!(msg, m);
+    }
+}

--- a/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
@@ -44,7 +44,7 @@ impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
     ///
     /// # Panics ...
     /// - if `modulus <= 1`.
-    /// - if `n < 1`.
+    /// - if `n < 1` or `n` does not fit into an [`i64`].
     pub fn init_dr_pfdh(
         n: impl Into<Z>, // security parameter
         modulus: impl Into<Modulus>,
@@ -82,7 +82,7 @@ impl CCSfromIBE<DualRegevIBE, Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
     /// ```
     ///
     /// # Panics ...
-    /// - if `n < 4`.
+    /// - if `n < 4` or `n` does not fit into an [`i64`].
     pub fn init_dr_pfdh_from_n(n: impl Into<Z>) -> Self {
         let n = n.into();
         assert!(

--- a/src/construction/signature/fdh.rs
+++ b/src/construction/signature/fdh.rs
@@ -6,12 +6,12 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This Module contains a general implementation of the [`Fdh`] scheme,
+//! This Module contains a general implementation of the [`FDH`] scheme,
 //! which only has to be instantiated with a corresponding PSF, a storage and
 //! a corresponding hash function.
 //!
-//! Implementation of a [`Fdh`]-signature scheme are thereby fairly easy,
-//! see [`Fdh::init_gpv`] that works with every PSF and a corresponding hash function
+//! Implementation of a [`FDH`]-signature scheme are thereby fairly easy,
+//! see [`FDH::init_gpv`] that works with every PSF and a corresponding hash function
 
 use super::SignatureScheme;
 use crate::{construction::hash::HashInto, primitive::psf::PSF};
@@ -25,7 +25,7 @@ pub mod serialize;
 /// This struct captures the general definition of a hash-then-sign signature scheme
 /// that uses a hash function as in [\[1\]](<../index.html#:~:text=[1]>) and a PSF.
 /// An explicit instantiation for defined types makes understanding this struct much
-/// easier, compare [`Fdh::init_gpv`].
+/// easier, compare [`FDH::init_gpv`].
 ///
 /// Implementing a function for a specific set of types(replacing the generic types)
 /// allows for easy implementation of the signature scheme. Any PSF and a corresponding
@@ -41,9 +41,9 @@ pub mod serialize;
 /// # Example
 /// ## Signature Scheme from [`PSFGPV`](crate::primitive::psf::gpv::PSFGPV)
 /// ```
-/// use qfall_crypto::construction::signature::{fdh::Fdh, SignatureScheme};
+/// use qfall_crypto::construction::signature::{fdh::FDH, SignatureScheme};
 ///
-/// let mut fdh = Fdh::init_gpv(4, 113, 17);
+/// let mut fdh = FDH::init_gpv(4, 113, 17);
 ///
 /// let m = "Hello World!";
 ///
@@ -53,7 +53,7 @@ pub mod serialize;
 /// assert!(fdh.vfy(m.to_owned(), &sigma, &pk));
 /// ```
 #[derive(Serialize)]
-pub struct Fdh<
+pub struct FDH<
     A,
     Trapdoor,
     Domain: Serialize + for<'a> Deserialize<'a>,
@@ -75,7 +75,7 @@ pub struct Fdh<
 }
 
 impl<A, Trapdoor, Domain, Range, T, Hash> SignatureScheme
-    for Fdh<A, Trapdoor, Domain, Range, T, Hash>
+    for FDH<A, Trapdoor, Domain, Range, T, Hash>
 where
     Domain: Clone + Serialize + for<'a> Deserialize<'a>,
     Range: PartialEq<Range>,

--- a/src/construction/signature/fdh/gpv.rs
+++ b/src/construction/signature/fdh/gpv.rs
@@ -75,7 +75,7 @@ impl Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
 }
 
 #[cfg(test)]
-mod text_fdh {
+mod test_fdh {
     use super::{Fdh, HashMatZq, PSFGPV};
     use crate::construction::signature::SignatureScheme;
     use qfall_math::{

--- a/src/construction/signature/fdh/gpv.rs
+++ b/src/construction/signature/fdh/gpv.rs
@@ -6,10 +6,10 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! A classical implementation of the [`Fdh`] scheme using the [`PSFGPV`]
+//! A classical implementation of the [`FDH`] scheme using the [`PSFGPV`]
 //! according to [\[1\]](<../index.html#:~:text=[1]>).
 
-use super::Fdh;
+use super::FDH;
 use crate::{
     construction::hash::sha256::HashMatZq, primitive::psf::gpv::PSFGPV,
     sample::g_trapdoor::gadget_parameters::GadgetParameters,
@@ -21,7 +21,7 @@ use qfall_math::{
 };
 use std::{collections::HashMap, marker::PhantomData};
 
-impl Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
+impl FDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
     /// Initializes an FDH signature scheme from a [`PSFGPV`].
     ///
     /// This function corresponds to an implementation of an FDH-signature
@@ -37,11 +37,11 @@ impl Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
     ///
     /// # Example
     /// ```
-    /// use qfall_crypto::construction::signature::{fdh::Fdh, SignatureScheme};
+    /// use qfall_crypto::construction::signature::{fdh::FDH, SignatureScheme};
     ///
     /// let m = "Hello World!";
     ///
-    /// let mut fdh = Fdh::init_gpv(4, 113, 17);
+    /// let mut fdh = FDH::init_gpv(4, 113, 17);
     /// let (pk, sk) = fdh.gen();
     ///
     /// let sigma = fdh.sign(m.to_string(), &sk, &pk);
@@ -76,7 +76,7 @@ impl Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
 
 #[cfg(test)]
 mod test_fdh {
-    use super::{Fdh, HashMatZq, PSFGPV};
+    use super::{HashMatZq, FDH, PSFGPV};
     use crate::construction::signature::SignatureScheme;
     use qfall_math::{
         integer::{MatZ, Z},
@@ -95,7 +95,7 @@ mod test_fdh {
         let s: Q = ((&n * &k).sqrt() + 1) * Q::from(2) * (Z::from(2) * &n * &k).log(2).unwrap();
         let modulus = Z::from(2).pow(&k).unwrap();
 
-        let mut fdh = Fdh::init_gpv(n, &modulus, &s);
+        let mut fdh = FDH::init_gpv(n, &modulus, &s);
         let (pk, sk) = fdh.gen();
 
         for i in 0..10 {
@@ -111,7 +111,7 @@ mod test_fdh {
     /// Ensure that an entry is actually added to the local storage.
     #[test]
     fn storage_filled() {
-        let mut fdh = Fdh::init_gpv(5, 1024, 10);
+        let mut fdh = FDH::init_gpv(5, 1024, 10);
 
         let m = "Hello World!";
         let (pk, sk) = fdh.gen();
@@ -123,7 +123,7 @@ mod test_fdh {
     /// Ensure that after deserialization the HashMap still contains all entries.
     #[test]
     fn reload_hashmap() {
-        let mut fdh = Fdh::init_gpv(5, 1024, 10);
+        let mut fdh = FDH::init_gpv(5, 1024, 10);
 
         // fill one entry in the HashMap
         let m = "Hello World!";
@@ -131,7 +131,7 @@ mod test_fdh {
         let _ = fdh.sign(m.to_owned(), &sk, &pk);
 
         let fdh_string = serde_json::to_string(&fdh).expect("Unable to create a json object");
-        let fdh_2: Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> =
+        let fdh_2: FDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> =
             serde_json::from_str(&fdh_string).unwrap();
 
         assert_eq!(fdh.storage, fdh_2.storage);

--- a/src/construction/signature/fdh/gpv_ring.rs
+++ b/src/construction/signature/fdh/gpv_ring.rs
@@ -6,10 +6,10 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! A ring implementation of the [`Fdh`] scheme using the [`PSFGPVRing`]
+//! A ring implementation of the [`FDH`] scheme using the [`PSFGPVRing`]
 //! according to [\[1\]](<../index.html#:~:text=[1]>).
 
-use super::Fdh;
+use super::FDH;
 use crate::{
     construction::hash::sha256::HashMatPolynomialRingZq, primitive::psf::gpv_ring::PSFGPVRing,
     sample::g_trapdoor::gadget_parameters::GadgetParametersRing,
@@ -22,7 +22,7 @@ use qfall_math::{
 use std::{collections::HashMap, marker::PhantomData};
 
 impl
-    Fdh<
+    FDH<
         MatPolynomialRingZq,
         (MatPolyOverZ, MatPolyOverZ),
         MatPolyOverZ,
@@ -49,9 +49,9 @@ impl
     ///
     /// # Example
     /// ```
-    /// use qfall_crypto::construction::signature::{fdh::Fdh, SignatureScheme};
+    /// use qfall_crypto::construction::signature::{fdh::FDH, SignatureScheme};
     ///
-    /// let mut fdh = Fdh::init_gpv_ring(8, 512, 100);
+    /// let mut fdh = FDH::init_gpv_ring(8, 512, 100);
     /// let (pk, sk) = fdh.gen();
     ///
     /// let m = &format!("Hello World!");
@@ -89,7 +89,7 @@ impl
 
 #[cfg(test)]
 mod test_fdh {
-    use super::{Fdh, PSFGPVRing};
+    use super::{PSFGPVRing, FDH};
     use crate::{
         construction::hash::sha256::HashMatPolynomialRingZq,
         construction::signature::SignatureScheme,
@@ -105,7 +105,7 @@ mod test_fdh {
     /// Ensure that the generated signature is valid.
     #[test]
     fn ensure_valid_signature_is_generated() {
-        let mut fdh = Fdh::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
         let (pk, sk) = fdh.gen();
 
         for i in 0..10 {
@@ -125,7 +125,7 @@ mod test_fdh {
     /// Ensure that an entry is actually added to the local storage.
     #[test]
     fn storage_filled() {
-        let mut fdh = Fdh::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
 
         let m = "Hello World!";
         let (pk, sk) = fdh.gen();
@@ -139,7 +139,7 @@ mod test_fdh {
     /// Ensure that after deserialization the HashMap still contains all entries.
     #[test]
     fn reload_hashmap() {
-        let mut fdh = Fdh::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
 
         // fill one entry in the HashMap
         let m = "Hello World!";
@@ -148,7 +148,7 @@ mod test_fdh {
 
         let fdh_string = serde_json::to_string(&fdh).expect("Unable to create a json object");
 
-        let fdh_2: Fdh<
+        let fdh_2: FDH<
             MatPolynomialRingZq,
             (MatPolyOverZ, MatPolyOverZ),
             MatPolyOverZ,

--- a/src/construction/signature/fdh/serialize.rs
+++ b/src/construction/signature/fdh/serialize.rs
@@ -6,7 +6,7 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! Allows to Deserialize an arbitrary [`Fdh`] instantiation
+//! Allows to Deserialize an arbitrary [`FDH`] instantiation
 
 use crate::{construction::hash::HashInto, primitive::psf::PSF};
 use serde::{
@@ -15,9 +15,9 @@ use serde::{
 };
 use std::{fmt, marker::PhantomData};
 
-use super::Fdh;
+use super::FDH;
 impl<'de, A, Trapdoor, Domain, Range, T, Hash> Deserialize<'de>
-    for Fdh<A, Trapdoor, Domain, Range, T, Hash>
+    for FDH<A, Trapdoor, Domain, Range, T, Hash>
 where
     Domain: Serialize + for<'a> Deserialize<'a>,
     T: PSF<A, Trapdoor, Domain, Range> + Serialize + for<'a> Deserialize<'a>,
@@ -54,7 +54,7 @@ where
             T: PSF<A, Trapdoor, Domain, Range> + Serialize + for<'a> Deserialize<'a>,
             Hash: HashInto<Range> + Serialize + for<'a> Deserialize<'a>,
         {
-            type Value = Fdh<A, Trapdoor, Domain, Range, T, Hash>;
+            type Value = FDH<A, Trapdoor, Domain, Range, T, Hash>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct $type")
@@ -90,7 +90,7 @@ where
                     }
                 }
 
-                Ok(Fdh {
+                Ok(FDH {
                     psf: Box::new(psf.unwrap()),
                     storage: storage.unwrap(),
                     hash: Box::new(hash.unwrap()),
@@ -109,7 +109,7 @@ where
             t: PhantomData,
             hash: PhantomData,
         };
-        deserializer.deserialize_struct("Fdh", FIELDS, struct_visitor)
+        deserializer.deserialize_struct("FDH", FIELDS, struct_visitor)
     }
 }
 
@@ -118,7 +118,7 @@ mod test_deserialization {
     use crate::{
         construction::{
             hash::sha256::HashMatZq,
-            signature::{fdh::Fdh, SignatureScheme},
+            signature::{fdh::FDH, SignatureScheme},
         },
         primitive::psf::gpv::PSFGPV,
     };
@@ -128,7 +128,7 @@ mod test_deserialization {
     #[allow(clippy::type_complexity)]
     #[test]
     fn deserialize_gpv() {
-        let mut fdh = Fdh::init_gpv(2, 127, 20);
+        let mut fdh = FDH::init_gpv(2, 127, 20);
 
         // fill one entry in the HashMap
         let m = "Hello World!";
@@ -136,7 +136,7 @@ mod test_deserialization {
         let _ = fdh.sign(m.to_owned(), &sk, &pk);
 
         let fdh_string = serde_json::to_string(&fdh).expect("Unable to create a json object");
-        let fdh_2: Result<Fdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>, _> =
+        let fdh_2: Result<FDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>, _> =
             serde_json::from_str(&fdh_string);
 
         assert!(fdh_2.is_ok());

--- a/src/construction/signature/pfdh.rs
+++ b/src/construction/signature/pfdh.rs
@@ -6,10 +6,10 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! This Module contains a general implementation of the [`Pfdh`] scheme.
+//! This Module contains a general implementation of the [`PFDH`] scheme.
 //!
-//! Implementation of a [`Pfdh`]-signature scheme are thereby fairly easy,
-//! see [`Pfdh::init_gpv`](crate::construction::signature::pfdh::gpv) that
+//! Implementation of a [`PFDH`]-signature scheme are thereby fairly easy,
+//! see [`PFDH::init_gpv`](crate::construction::signature::pfdh::gpv) that
 //! works with every PSF and a corresponding hash function.
 
 use super::SignatureScheme;
@@ -22,7 +22,7 @@ pub mod gpv;
 pub mod serialize;
 
 #[derive(Serialize)]
-pub struct Pfdh<
+pub struct PFDH<
     A,
     Trapdoor,
     Domain: Serialize + for<'a> Deserialize<'a>,
@@ -46,7 +46,7 @@ pub struct Pfdh<
 }
 
 impl<A, Trapdoor, Domain, Range, T, Hash> SignatureScheme
-    for Pfdh<A, Trapdoor, Domain, Range, T, Hash>
+    for PFDH<A, Trapdoor, Domain, Range, T, Hash>
 where
     Domain: Clone + Serialize + for<'a> Deserialize<'a>,
     Range: PartialEq<Range>,

--- a/src/construction/signature/pfdh/gpv.rs
+++ b/src/construction/signature/pfdh/gpv.rs
@@ -6,10 +6,10 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! A classical implementation of the [`Pfdh`] scheme using the [`PSFGPV`]
+//! A classical implementation of the [`PFDH`] scheme using the [`PSFGPV`]
 //! according to [\[1\]](<../index.html#:~:text=[1]>).
 
-use super::Pfdh;
+use super::PFDH;
 use crate::{
     construction::hash::sha256::HashMatZq, primitive::psf::gpv::PSFGPV,
     sample::g_trapdoor::gadget_parameters::GadgetParameters,
@@ -21,7 +21,7 @@ use qfall_math::{
 };
 use std::marker::PhantomData;
 
-impl Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
+impl PFDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
     /// Initializes an PFDH signature scheme from a [`PSFGPV`].
     ///
     /// This function corresponds to an implementation of an PFDH-signature
@@ -38,9 +38,9 @@ impl Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
     ///
     /// # Example
     /// ```
-    /// use qfall_crypto::construction::signature::{pfdh::Pfdh, SignatureScheme};
+    /// use qfall_crypto::construction::signature::{pfdh::PFDH, SignatureScheme};
     ///
-    /// let mut pfdh = Pfdh::init_gpv(4, 113, 17, 128);
+    /// let mut pfdh = PFDH::init_gpv(4, 113, 17, 128);
     ///
     /// let m = "Hello World!";
     ///
@@ -84,7 +84,7 @@ impl Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
 
 #[cfg(test)]
 mod test_pfdh {
-    use super::Pfdh;
+    use super::PFDH;
     use crate::construction::signature::SignatureScheme;
     use qfall_math::{integer::Z, rational::Q, traits::Pow};
 
@@ -98,7 +98,7 @@ mod test_pfdh {
         let s: Q = ((&n * &k).sqrt() + 1) * Q::from(2) * (Z::from(2) * &n * &k).log(2).unwrap();
         let modulus = Z::from(2).pow(&k).unwrap();
 
-        let mut pfdh = Pfdh::init_gpv(n, &modulus, &s, 128);
+        let mut pfdh = PFDH::init_gpv(n, &modulus, &s, 128);
         let (pk, sk) = pfdh.gen();
 
         for i in 0..10 {

--- a/src/construction/signature/pfdh/gpv.rs
+++ b/src/construction/signature/pfdh/gpv.rs
@@ -83,7 +83,7 @@ impl Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq> {
 }
 
 #[cfg(test)]
-mod text_fdh {
+mod test_pfdh {
     use super::Pfdh;
     use crate::construction::signature::SignatureScheme;
     use qfall_math::{integer::Z, rational::Q, traits::Pow};

--- a/src/construction/signature/pfdh/serialize.rs
+++ b/src/construction/signature/pfdh/serialize.rs
@@ -6,9 +6,9 @@
 // the terms of the Mozilla Public License Version 2.0 as published by the
 // Mozilla Foundation. See <https://mozilla.org/en-US/MPL/2.0/>.
 
-//! Allows to Deserialize an arbitrary [`Pfdh`] instantiation
+//! Allows to Deserialize an arbitrary [`PFDH`] instantiation
 
-use super::Pfdh;
+use super::PFDH;
 use crate::{construction::hash::HashInto, primitive::psf::PSF};
 use serde::{
     de::{Error, MapAccess, Visitor},
@@ -17,7 +17,7 @@ use serde::{
 use std::{fmt, marker::PhantomData};
 
 impl<'de, A, Trapdoor, Domain, Range, T, Hash> Deserialize<'de>
-    for Pfdh<A, Trapdoor, Domain, Range, T, Hash>
+    for PFDH<A, Trapdoor, Domain, Range, T, Hash>
 where
     Domain: Serialize + for<'a> Deserialize<'a>,
     T: PSF<A, Trapdoor, Domain, Range> + Serialize + for<'a> Deserialize<'a>,
@@ -55,7 +55,7 @@ where
             T: PSF<A, Trapdoor, Domain, Range> + Serialize + for<'a> Deserialize<'a>,
             Hash: HashInto<Range> + Serialize + for<'a> Deserialize<'a>,
         {
-            type Value = Pfdh<A, Trapdoor, Domain, Range, T, Hash>;
+            type Value = PFDH<A, Trapdoor, Domain, Range, T, Hash>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct $type")
@@ -91,7 +91,7 @@ where
                     }
                 }
 
-                Ok(Pfdh {
+                Ok(PFDH {
                     psf: Box::new(psf.unwrap()),
                     hash: Box::new(hash.unwrap()),
                     randomness_length: randomness_length.unwrap(),
@@ -111,7 +111,7 @@ where
             t: PhantomData,
             hash: PhantomData,
         };
-        deserializer.deserialize_struct("Pfdh", FIELDS, struct_visitor)
+        deserializer.deserialize_struct("PFDH", FIELDS, struct_visitor)
     }
 }
 
@@ -120,7 +120,7 @@ mod test_deserialization {
     use crate::{
         construction::{
             hash::sha256::HashMatZq,
-            signature::{pfdh::Pfdh, SignatureScheme},
+            signature::{pfdh::PFDH, SignatureScheme},
         },
         primitive::psf::gpv::PSFGPV,
     };
@@ -130,14 +130,14 @@ mod test_deserialization {
     #[allow(clippy::type_complexity)]
     #[test]
     fn deserialize_gpv() {
-        let mut pfdh = Pfdh::init_gpv(2, 127, 20, 1233);
+        let mut pfdh = PFDH::init_gpv(2, 127, 20, 1233);
 
         let m = "Hello World!";
         let (pk, sk) = pfdh.gen();
         let signature = pfdh.sign(m.to_owned(), &sk, &pk);
 
         let pfdh_string = serde_json::to_string(&pfdh).expect("Unable to create a json object");
-        let pfdh_2: Result<Pfdh<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>, _> =
+        let pfdh_2: Result<PFDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, HashMatZq>, _> =
             serde_json::from_str(&pfdh_string);
 
         assert!(pfdh_2.is_ok());


### PR DESCRIPTION
**Description**
This PR implements...
- [x] PKEncryptionMut for more advanced schemes where self has to be mutable
- [x] a generic construction for PKEncryptionMut, which is CCA-secure
- [x] this construction instantiated with the DualRegevIBE and PFDH as a signature

This branch will fail first. Once https://github.com/qfall/math/pull/392 has gotten thru, it should work properly as the concrete instantiation needs MatZq to implement Into<String>, which is part of PR 392 of our math-crate.

**Testing**
- [x] I added basic working examples (possibly in doc-comment)

**Checklist:**
- [x] I have performed a self-review of my own code
  - [x] The code provides good readability and maintainability s.t. it fulfills best practices like talking code, modularity, ...
    - [x] The chosen implementation is not more complex than it has to be
  - [x] My code should work as intended and no side effects occur (e.g. memory leaks)
  - [x] The doc comments fit our style guide
  - [x] I have credited related sources if needed
