### PR TITLE
Patch Clippy

### DIFF
--- a/src/construction.rs
+++ b/src/construction.rs
@@ -12,9 +12,9 @@
 //! A construction is build the same way:
 //!
 //! 1. A trait that combines the common feature, e.g.
-//! [`public key encryption`](pk_encryption::PKEncryptionScheme).
+//!     [`public key encryption`](pk_encryption::PKEncryptionScheme).
 //! 2. Explicit implementations of the trait, e.g.
-//! [`RingLPR`](pk_encryption::RingLPR).
+//!     [`RingLPR`](pk_encryption::RingLPR).
 
 pub mod hash;
 pub mod identity_based_encryption;

--- a/src/construction/hash/sha256.rs
+++ b/src/construction/hash/sha256.rs
@@ -249,7 +249,7 @@ impl HashInto<MatPolynomialRingZq> for HashMatPolynomialRingZq {
     fn hash(&self, m: &str) -> MatPolynomialRingZq {
         let highest_deg = self.modulus.get_degree();
         let embedding =
-            (&hash_to_mat_zq_sha256(m, self.rows * highest_deg, self.cols, &self.modulus.get_q()))
+            (&hash_to_mat_zq_sha256(m, self.rows * highest_deg, self.cols, self.modulus.get_q()))
                 .into();
         let poly_mat = MatPolyOverZ::from_coefficient_embedding_to_matrix(&embedding, highest_deg);
         MatPolynomialRingZq::from((&poly_mat, &self.modulus))

--- a/src/construction/hash/sis.rs
+++ b/src/construction/hash/sis.rs
@@ -11,9 +11,9 @@
 //!
 //! The main references are listed in the following:
 //! - \[1\] Peikert, Chris (2016).
-//! A decade of lattice cryptography.
-//! In: Theoretical Computer Science 10.4.
-//! <https://web.eecs.umich.edu/~cpeikert/pubs/lattice-survey.pdf>
+//!     A decade of lattice cryptography.
+//!     In: Theoretical Computer Science 10.4.
+//!     <https://web.eecs.umich.edu/~cpeikert/pubs/lattice-survey.pdf>
 
 use qfall_math::{
     error::MathError,
@@ -75,7 +75,7 @@ impl SISHash {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `n <= 0`.
+    ///     if `n <= 0`.
     pub fn gen(n: impl Into<Z>, m: impl Into<Z>, q: impl Into<Z>) -> Result<Self, MathError> {
         let n: Z = n.into();
         let m: Z = m.into();
@@ -109,8 +109,8 @@ impl SISHash {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if `m < n log q`, or `q <= ⌈sqrt(n log q)⌉`
-    /// as collision-resistance would otherwise not be ensured.
+    ///     if `m < n log q`, or `q <= ⌈sqrt(n log q)⌉`
+    ///     as collision-resistance would otherwise not be ensured.
     pub fn check_security(&self) -> Result<(), MathError> {
         let n: Z = self.key.get_num_rows().into();
         let m: Z = self.key.get_num_columns().into();

--- a/src/construction/identity_based_encryption.rs
+++ b/src/construction/identity_based_encryption.rs
@@ -13,13 +13,13 @@
 //! The main references are listed in the following
 //! and will be further referenced in submodules by these numbers:
 //! - \[1\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-//! Trapdoors for hard lattices and new cryptographic constructions.
-//! In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-//! <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+//!     Trapdoors for hard lattices and new cryptographic constructions.
+//!     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+//!     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
 //! - \[2\] Regev, Oded (2009).
-//! On lattices, learning with errors, random linear codes, and cryptography.
-//! In: Journal of the ACM 6.
-//! <https://dl.acm.org/doi/pdf/10.1145/1568318.1568324>
+//!     On lattices, learning with errors, random linear codes, and cryptography.
+//!     In: Journal of the ACM 6.
+//!     <https://dl.acm.org/doi/pdf/10.1145/1568318.1568324>
 
 mod dual_regev_ibe;
 

--- a/src/construction/identity_based_encryption/dual_regev_ibe.rs
+++ b/src/construction/identity_based_encryption/dual_regev_ibe.rs
@@ -37,7 +37,7 @@ use std::collections::HashMap;
 /// - `dual_regev`: a [`DualRegev`] instance with fitting parameters `n`, `m`, `q`, `alpha`
 /// - `psf`: specifies the PSF used for extracting secret keys
 /// - `storage`: is a [`HashMap`] which stores all previously computed secret keys
-/// corresponding to their identities
+///     corresponding to their identities
 ///
 /// # Examples
 /// ```
@@ -135,7 +135,7 @@ impl DualRegevIBE {
 
         // generate prime q in [n^power / 2, n^power]
         let upper_bound: Z = n.pow(power).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -181,8 +181,8 @@ impl DualRegevIBE {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure Dual Regev public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure Dual Regev public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q = Q::from(&self.dual_regev.q);
 
@@ -234,8 +234,8 @@ impl DualRegevIBE {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct Dual Regev IBE public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct Dual Regev IBE public key encryption instance.
     pub fn check_correctness(&self) -> Result<(), MathError> {
         if self.dual_regev.n <= Z::ONE {
             return Err(MathError::InvalidIntegerInput(String::from(
@@ -308,9 +308,9 @@ impl IBEScheme for DualRegevIBE {
     /// Parameters:
     /// - `master_pk`: The master public key for the encryption scheme
     /// - `master_sk`: Zhe master secret key of the encryption scheme, namely
-    /// the trapdoor for the [`PSF`]
+    ///     the trapdoor for the [`PSF`]
     /// - `identity`: The identity, for which the corresponding secret key
-    ///  should be returned
+    ///     should be returned
     ///
     /// Returns the corresponding secret key of `identity` under public key
     /// `master_pk`.
@@ -382,7 +382,7 @@ impl IBEScheme for DualRegevIBE {
         message: impl Into<Z>,
     ) -> Self::Cipher {
         let identity_based_pk =
-            hash_to_mat_zq_sha256(identity, master_pk.get_num_rows(), 1, &master_pk.get_mod());
+            hash_to_mat_zq_sha256(identity, master_pk.get_num_rows(), 1, master_pk.get_mod());
         self.dual_regev.enc(
             &master_pk.concat_horizontal(&identity_based_pk).unwrap(),
             message,
@@ -436,11 +436,12 @@ mod test_dual_regev_ibe {
         let _ = DualRegevIBE::new(2u8, 2u16, 2u32, 2u64);
         let _ = DualRegevIBE::new(2u16, 2u64, 2i32, 2i64);
         let _ = DualRegevIBE::new(2i16, 2i64, 2u32, 2u8);
-        let _ = DualRegevIBE::new(Z::from(2), &Z::from(2), 2u8, 2i8);
+        let _ = DualRegevIBE::new(Z::from(2), Z::from(2), 2u8, 2i8);
     }
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let _ = DualRegevIBE::new_from_n(4u8);
         let _ = DualRegevIBE::new_from_n(4u16);

--- a/src/construction/pk_encryption.rs
+++ b/src/construction/pk_encryption.rs
@@ -13,25 +13,25 @@
 //! The main references are listed in the following
 //! and will be further referenced in submodules by these numbers:
 //! - \[1\] Peikert, Chris (2016).
-//! A decade of lattice cryptography.
-//! In: Theoretical Computer Science 10.4.
-//! <https://web.eecs.umich.edu/~cpeikert/pubs/lattice-survey.pdf>
+//!     A decade of lattice cryptography.
+//!     In: Theoretical Computer Science 10.4.
+//!     <https://web.eecs.umich.edu/~cpeikert/pubs/lattice-survey.pdf>
 //! - \[2\] Gentry, Craig and Peikert, Chris and Vaikuntanathan, Vinod (2008).
-//! Trapdoors for hard lattices and new cryptographic constructions.
-//! In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
-//! <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
+//!     Trapdoors for hard lattices and new cryptographic constructions.
+//!     In: Proceedings of the fortieth annual ACM symposium on Theory of computing.
+//!     <https://dl.acm.org/doi/pdf/10.1145/1374376.1374407>
 //! - \[3\] Regev, Oded (2009).
-//! On lattices, learning with errors, random linear codes, and cryptography.
-//! In: Journal of the ACM 6.
-//! <https://dl.acm.org/doi/pdf/10.1145/1568318.1568324>
+//!     On lattices, learning with errors, random linear codes, and cryptography.
+//!     In: Journal of the ACM 6.
+//!     <https://dl.acm.org/doi/pdf/10.1145/1568318.1568324>
 //! - \[4\] Lindner, R., and C. Peikert (2011).
-//! Better key sizes (and attacks) for LWE-based encryption.
-//! In: Topics in Cryptology -  RSA Conference 2011, Springer.
-//! <https://eprint.iacr.org/2010/613.pdf>
+//!     Better key sizes (and attacks) for LWE-based encryption.
+//!     In: Topics in Cryptology -  RSA Conference 2011, Springer.
+//!     <https://eprint.iacr.org/2010/613.pdf>
 //! - \[5\] Canetti, R., Halevi, S., and Katz, J. (2004).
-//! Chosen-ciphertext security from identity-based encryption.
-//! In: Advances in Cryptology - EUROCRYPT 2004.
-//! <https://link.springer.com/content/pdf/10.1007/b97182.pdf>
+//!     Chosen-ciphertext security from identity-based encryption.
+//!     In: Advances in Cryptology - EUROCRYPT 2004.
+//!     <https://link.springer.com/content/pdf/10.1007/b97182.pdf>
 
 mod ccs_from_ibe;
 mod dual_regev;
@@ -148,7 +148,7 @@ pub trait GenericMultiBitEncryption: PKEncryptionScheme {
     /// Parameters:
     /// - `sk`: specifies the secret key used for decryption
     /// - `cipher`: specifies a slice of ciphers containing several [`PKEncryptionScheme::Cipher`] instances
-    /// to be decrypted
+    ///     to be decrypted
     ///
     /// Returns the decryption of `cipher` as a [`Z`] instance.
     fn dec_multiple_bits(&self, sk: &Self::SecretKey, cipher: &[Self::Cipher]) -> Z {

--- a/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
+++ b/src/construction/pk_encryption/ccs_from_ibe/dual_regev_ibe_pfdh.rs
@@ -31,7 +31,7 @@ impl CCSfromIBE<DualRegevIBE, PFDH<MatZq, (MatZ, MatQ), MatZ, MatZq, PSFGPV, Has
     /// - `r`: specifies the Gaussian parameter used for the [`PSFGPV`] for the [`PFDH`]
     /// - `randomness_length`: specifies the number of bits added to the message before signing
     /// - `alpha`: specifies the Gaussian parameter used for encryption in
-    /// [`DualRegev`](crate::construction::pk_encryption::DualRegev) in the [`DualRegevIBE`]
+    ///     [`DualRegev`](crate::construction::pk_encryption::DualRegev) in the [`DualRegevIBE`]
     ///
     /// Returns an explicit implementation of an IND-CCA-secure public key encryption scheme.
     ///

--- a/src/construction/pk_encryption/dual_regev.rs
+++ b/src/construction/pk_encryption/dual_regev.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// - `m`: defines the dimension of the underlying lattice
 /// - `q`: specifies the modulus over which the encryption is computed
 /// - `alpha`:  specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -71,7 +71,7 @@ impl DualRegev {
     /// - `m`: specifies the number of columns of matrix `A`
     /// - `q`: specifies the modulus
     /// - `alpha`:  specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns [`DualRegev`] PK encryption instance.
     ///
@@ -183,7 +183,7 @@ impl DualRegev {
 
         // generate prime q in [n^power / 2, n^power]
         let upper_bound: Z = n.pow(power).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -223,8 +223,8 @@ impl DualRegev {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct Dual Regev public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct Dual Regev public key encryption instance.
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q);
 
@@ -271,8 +271,8 @@ impl DualRegev {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure Dual Regev public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure Dual Regev public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q);
 
@@ -364,7 +364,7 @@ impl PKEncryptionScheme for DualRegev {
     /// - s <- Z_q^n
     /// - e <- χ^(m+1)
     /// - c^t = s^t * A + e^t + [0^{1xn} | msg *  ⌊q/2⌋]
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, the ciphertext `c` is returned as a vector of type [`MatZq`].
     ///
@@ -404,7 +404,7 @@ impl PKEncryptionScheme for DualRegev {
 
         // hide message in last entry
         // compute msg * ⌊q/2⌋
-        let msg_q_half = message * Z::from(&self.q).div_floor(&Z::from(2));
+        let msg_q_half = message * Z::from(&self.q).div_floor(2);
         // set last entry of c = last_entry + msg * ⌊q/2⌋
         let last_entry: Zq = c.get_entry(-1, 0).unwrap();
         c.set_entry(-1, 0, last_entry + msg_q_half).unwrap();
@@ -440,7 +440,7 @@ impl PKEncryptionScheme for DualRegev {
             .unwrap();
         let result: Zq = (cipher.transpose() * tmp).get_entry(0, 0).unwrap();
 
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
 
         if result.distance(Z::ZERO) > result.distance(q_half) {
             Z::ONE
@@ -464,7 +464,7 @@ mod test_pp_generation {
         let _ = DualRegev::new(2u8, 2u16, 2u32, 2u64);
         let _ = DualRegev::new(2u16, 2u64, 2i32, 2i64);
         let _ = DualRegev::new(2i16, 2i64, 2u32, 2u8);
-        let _ = DualRegev::new(Z::from(2), &Z::from(2), 2u8, 2i8);
+        let _ = DualRegev::new(Z::from(2), Z::from(2), 2u8, 2i8);
     }
 
     /// Checks whether `new_from_n` works properly for different choices of n.
@@ -503,6 +503,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let _ = DualRegev::new_from_n(10u8);
         let _ = DualRegev::new_from_n(10u16);

--- a/src/construction/pk_encryption/dual_regev_discrete_gauss.rs
+++ b/src/construction/pk_encryption/dual_regev_discrete_gauss.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// - `r`: specifies the Gaussian parameter used for SampleD,
 ///   i.e. used for encryption
 /// - `alpha`: specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -77,7 +77,7 @@ impl DualRegevWithDiscreteGaussianRegularity {
     /// - `r`: specifies the Gaussian parameter used for SampleD,
     ///   i.e. used for encryption
     /// - `alpha`: specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns a [`DualRegevWithDiscreteGaussianRegularity`] PK encryption instance.
     ///
@@ -194,7 +194,7 @@ impl DualRegevWithDiscreteGaussianRegularity {
 
         // generate prime q in [n^power / 2, n^power]
         let upper_bound: Z = n.pow(power).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -236,8 +236,8 @@ impl DualRegevWithDiscreteGaussianRegularity {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct DualRegevWithDiscreteGaussianRegularity public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct DualRegevWithDiscreteGaussianRegularity public key encryption instance.
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let q: Z = Z::from(&self.q);
 
@@ -285,8 +285,8 @@ impl DualRegevWithDiscreteGaussianRegularity {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure DualRegevWithDiscreteGaussianRegularity public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure DualRegevWithDiscreteGaussianRegularity public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q: Z = Z::from(&self.q);
 
@@ -383,7 +383,7 @@ impl PKEncryptionScheme for DualRegevWithDiscreteGaussianRegularity {
     /// - vec_x <- χ^m, x <- χ
     /// - p = A^t * s + vec_x
     /// - c = u^t * s + x + message *  ⌊q/2⌋
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, `cipher = (p, c)` is returned.
     ///
@@ -424,7 +424,7 @@ impl PKEncryptionScheme for DualRegevWithDiscreteGaussianRegularity {
         // p = u^t * s + vec_x
         let vec_p = &pk.0.transpose() * &vec_s + vec_x;
         // c = u^t * s + x + msg *  ⌊q/2⌋
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
         let c = pk.1.dot_product(&vec_s).unwrap() + x + message * q_half;
 
         (vec_p, c)
@@ -455,7 +455,7 @@ impl PKEncryptionScheme for DualRegevWithDiscreteGaussianRegularity {
     fn dec(&self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
         let result = &cipher.1 - sk.dot_product(&cipher.0).unwrap();
 
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
 
         if result.distance(Z::ZERO) > result.distance(q_half) {
             Z::ONE
@@ -480,7 +480,7 @@ mod test_pp_generation {
         let _ = DualRegevWithDiscreteGaussianRegularity::new(2u16, 2u64, 2i32, 2i64, 2i16);
         let _ = DualRegevWithDiscreteGaussianRegularity::new(2i16, 2i64, 2u32, 2u8, 2u16);
         let _ =
-            DualRegevWithDiscreteGaussianRegularity::new(Z::from(2), &Z::from(2), 2u8, 2i8, 2u32);
+            DualRegevWithDiscreteGaussianRegularity::new(Z::from(2), Z::from(2), 2u8, 2i8, 2u32);
     }
 
     /// Checks whether `new_from_n` works properly for different choices of n.
@@ -524,6 +524,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn new_from_n_availability() {
         let _ = DualRegevWithDiscreteGaussianRegularity::new_from_n(2u8);
         let _ = DualRegevWithDiscreteGaussianRegularity::new_from_n(2u16);

--- a/src/construction/pk_encryption/lpr.rs
+++ b/src/construction/pk_encryption/lpr.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 /// - `n`: specifies the security parameter, which is not equal to the bit-security level
 /// - `q`: specifies the modulus over which the encryption is computed
 /// - `alpha`: specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -68,7 +68,7 @@ impl LPR {
     ///   of the uniform at random instantiated matrix `A`
     /// - `q`: specifies the modulus
     /// - `alpha`: specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns a correct and secure [`LPR`] PK encryption instance or
     /// a [`MathError`] if the instance would not be correct or secure.
@@ -166,7 +166,7 @@ impl LPR {
 
         // generate prime q in [n^3 / 2, n^3]
         let upper_bound: Z = n.pow(3).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -214,10 +214,10 @@ impl LPR {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct LPR public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct LPR public key encryption instance.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if the value does not fit into an [`i64`]
+    ///     if the value does not fit into an [`i64`]
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let n_i64 = i64::try_from(&self.n)?;
 
@@ -267,8 +267,8 @@ impl LPR {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure LPR public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure LPR public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q);
 
@@ -324,7 +324,7 @@ impl PKEncryptionScheme for LPR {
     /// - e <- χ^n
     /// - b^t = s^t * A + e^t
     /// - A = [A^t | b]^t
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, `pk = A` and `sk = s` are returned.
     ///
@@ -373,7 +373,7 @@ impl PKEncryptionScheme for LPR {
     /// - r <- χ^n
     /// - e <- χ^{n+1}
     /// - c = A * r + e + [0^{1 x n} | msg *  ⌊q/2⌋]^t
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, cipher `c` as a vector of type [`MatZq`] is returned.
     ///
@@ -421,7 +421,7 @@ impl PKEncryptionScheme for LPR {
 
         // hide message in last entry
         // compute msg * ⌊q/2⌋
-        let msg_q_half = message * Z::from(&self.q).div_floor(&Z::from(2));
+        let msg_q_half = message * Z::from(&self.q).div_floor(2);
         // set last entry of c = last_entry + msg * ⌊q/2⌋
         let last_entry: Zq = c.get_entry(-1, 0).unwrap();
         c.set_entry(-1, 0, last_entry + msg_q_half).unwrap();
@@ -458,7 +458,7 @@ impl PKEncryptionScheme for LPR {
             .dot_product(cipher)
             .unwrap();
 
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
 
         if result.distance(Z::ZERO) > result.distance(q_half) {
             Z::ONE
@@ -522,6 +522,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let _ = LPR::new_from_n(10u8);
         let _ = LPR::new_from_n(10u16);

--- a/src/construction/pk_encryption/regev.rs
+++ b/src/construction/pk_encryption/regev.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// - `m`: defines the dimension of the underlying lattice
 /// - `q`: specifies the modulus over which the encryption is computed
 /// - `alpha`:  specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -71,7 +71,7 @@ impl Regev {
     /// - `m`: specifies the number of columns of matrix `A`
     /// - `q`: specifies the modulus
     /// - `alpha`:  specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns a [`Regev`] PK encryption instance.
     ///
@@ -183,7 +183,7 @@ impl Regev {
 
         // generate prime q in [n^power / 2, n^power]
         let upper_bound: Z = n.pow(power).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -224,8 +224,8 @@ impl Regev {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct Regev public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct Regev public key encryption instance.
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q);
 
@@ -272,8 +272,8 @@ impl Regev {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure Regev public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure Regev public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q);
 
@@ -336,7 +336,7 @@ impl PKEncryptionScheme for Regev {
     /// - e^t <- χ^m
     /// - b^t = s^t * A + e^t
     /// - A = [A^t | b]^t
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, `pk = A` and `sk = s` of type [`MatZq`] are returned.
     ///
@@ -405,7 +405,7 @@ impl PKEncryptionScheme for Regev {
 
         // hide message in last entry
         // compute msg * ⌊q/2⌋
-        let msg_q_half = message * Z::from(&self.q).div_floor(&Z::from(2));
+        let msg_q_half = message * Z::from(&self.q).div_floor(2);
         // set last entry of c = last_entry + msg * ⌊q/2⌋
         let last_entry: Zq = c.get_entry(-1, 0).unwrap();
         c.set_entry(-1, 0, last_entry + msg_q_half).unwrap();
@@ -442,7 +442,7 @@ impl PKEncryptionScheme for Regev {
             .dot_product(cipher)
             .unwrap();
 
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
 
         if result.distance(Z::ZERO) > result.distance(q_half) {
             Z::ONE
@@ -466,7 +466,7 @@ mod test_pp_generation {
         let _ = Regev::new(2u8, 2u16, 2u32, 2u64);
         let _ = Regev::new(2u16, 2u64, 2i32, 2i64);
         let _ = Regev::new(2i16, 2i64, 2u32, 2u8);
-        let _ = Regev::new(Z::from(2), &Z::from(2), 2u8, 2i8);
+        let _ = Regev::new(Z::from(2), Z::from(2), 2u8, 2i8);
     }
 
     /// Checks whether `new_from_n` works properly for different choices of n.
@@ -505,6 +505,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let _ = Regev::new_from_n(10u8);
         let _ = Regev::new_from_n(10u16);

--- a/src/construction/pk_encryption/regev_discrete_gauss.rs
+++ b/src/construction/pk_encryption/regev_discrete_gauss.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// - `r`: specifies the Gaussian parameter used for SampleD,
 ///   i.e. used for encryption
 /// - `alpha`: specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -77,7 +77,7 @@ impl RegevWithDiscreteGaussianRegularity {
     /// - `r`: specifies the Gaussian parameter used for SampleD,
     ///   i.e. used for encryption
     /// - `alpha`: specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns a [`RegevWithDiscreteGaussianRegularity`] PK encryption instance.
     ///
@@ -194,7 +194,7 @@ impl RegevWithDiscreteGaussianRegularity {
 
         // generate prime q in [n^power / 2, n^power]
         let upper_bound: Z = n.pow(power).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -236,8 +236,8 @@ impl RegevWithDiscreteGaussianRegularity {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct RegevWithDiscreteGaussianRegularity public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct RegevWithDiscreteGaussianRegularity public key encryption instance.
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let q: Z = Z::from(&self.q);
 
@@ -285,8 +285,8 @@ impl RegevWithDiscreteGaussianRegularity {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure RegevWithDiscreteGaussianRegularity public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure RegevWithDiscreteGaussianRegularity public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q: Z = Z::from(&self.q);
 
@@ -355,7 +355,7 @@ impl PKEncryptionScheme for RegevWithDiscreteGaussianRegularity {
     /// - A <- Z_q^{n x m}
     /// - x <- χ^m
     /// - p = A^t * s + x
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, `pk = (A, p)` and `sk = s` are returned.
     ///
@@ -420,7 +420,7 @@ impl PKEncryptionScheme for RegevWithDiscreteGaussianRegularity {
         // u = A * e
         let vec_u = &pk.0 * &vec_e;
         // c = p^t * e + msg *  ⌊q/2⌋
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
         let c = pk.1.dot_product(&vec_e).unwrap() + message * q_half;
 
         (vec_u, c)
@@ -451,7 +451,7 @@ impl PKEncryptionScheme for RegevWithDiscreteGaussianRegularity {
     fn dec(&self, sk: &Self::SecretKey, cipher: &Self::Cipher) -> Z {
         let result = &cipher.1 - sk.dot_product(&cipher.0).unwrap();
 
-        let q_half = Z::from(&self.q).div_floor(&Z::from(2));
+        let q_half = Z::from(&self.q).div_floor(2);
 
         if result.distance(Z::ZERO) > result.distance(q_half) {
             Z::ONE
@@ -475,7 +475,7 @@ mod test_pp_generation {
         let _ = RegevWithDiscreteGaussianRegularity::new(2u8, 2u16, 2u32, 2u64, 2i8);
         let _ = RegevWithDiscreteGaussianRegularity::new(2u16, 2u64, 2i32, 2i64, 2i16);
         let _ = RegevWithDiscreteGaussianRegularity::new(2i16, 2i64, 2u32, 2u8, 2u16);
-        let _ = RegevWithDiscreteGaussianRegularity::new(Z::from(2), &Z::from(2), 2u8, 2i8, 2u32);
+        let _ = RegevWithDiscreteGaussianRegularity::new(Z::from(2), Z::from(2), 2u8, 2i8, 2u32);
     }
 
     /// Checks whether `new_from_n` works properly for different choices of n.
@@ -519,6 +519,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn new_from_n_availability() {
         let _ = RegevWithDiscreteGaussianRegularity::new_from_n(2u8);
         let _ = RegevWithDiscreteGaussianRegularity::new_from_n(2u16);

--- a/src/construction/pk_encryption/ring_lpr.rs
+++ b/src/construction/pk_encryption/ring_lpr.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// - `n`: specifies the security parameter, which is not equal to the bit-security level
 /// - `q`: specifies the modulus over which the encryption is computed
 /// - `alpha`: specifies the Gaussian parameter used for independent
-/// sampling from the discrete Gaussian distribution
+///     sampling from the discrete Gaussian distribution
 ///
 /// # Examples
 /// ```
@@ -71,7 +71,7 @@ impl RingLPR {
     ///   of the uniform at random instantiated matrix `A`
     /// - `q`: specifies the modulus
     /// - `alpha`: specifies the Gaussian parameter used for independent
-    /// sampling from the discrete Gaussian distribution
+    ///     sampling from the discrete Gaussian distribution
     ///
     /// Returns a correct and secure [`RingLPR`] PK encryption instance or
     /// a [`MathError`] if the instance would not be correct or secure.
@@ -171,7 +171,7 @@ impl RingLPR {
 
         // generate prime q in [n^3 / 2, n^3]
         let upper_bound: Z = n.pow(3).unwrap();
-        let lower_bound = upper_bound.div_ceil(&Z::from(2));
+        let lower_bound = upper_bound.div_ceil(2);
         // prime used due to guide from GPV08 after Proposition 8.1
         // on how to choose appropriate parameters, but prime is not
         // necessarily needed for this scheme to be correct or secure
@@ -221,10 +221,10 @@ impl RingLPR {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// correct RingLPR public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     correct RingLPR public key encryption instance.
     /// - Returns a [`MathError`] of type [`ConversionError`](MathError::ConversionError)
-    /// if the value does not fit into an [`i64`].
+    ///     if the value does not fit into an [`i64`].
     pub fn check_correctness(&self) -> Result<(), MathError> {
         let n_i64 = i64::try_from(&self.n)?;
 
@@ -289,8 +289,8 @@ impl RingLPR {
     ///
     /// # Errors and Failures
     /// - Returns a [`MathError`] of type [`InvalidIntegerInput`](MathError::InvalidIntegerInput)
-    /// if at least one parameter was not chosen appropriately for a
-    /// secure RingLPR public key encryption instance.
+    ///     if at least one parameter was not chosen appropriately for a
+    ///     secure RingLPR public key encryption instance.
     pub fn check_security(&self) -> Result<(), MathError> {
         let q = Z::from(&self.q.get_q());
 
@@ -356,7 +356,7 @@ impl PKEncryptionScheme for RingLPR {
     /// - s <- χ
     /// - e <- χ
     /// - b = s * a + e
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, `pk = (a, b)` and `sk = s` are returned.
     ///
@@ -401,7 +401,7 @@ impl PKEncryptionScheme for RingLPR {
     /// - u = a * r + e1
     /// - v = b * r + e2 + mu * q/2
     /// - c = (u, v)
-    /// where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
+    ///     where χ is discrete Gaussian distributed with center 0 and Gaussian parameter q * α.
     ///
     /// Then, cipher `c = (u, v)` as a polynomial of type [`PolynomialRingZq`] is returned.
     ///
@@ -566,6 +566,7 @@ mod test_pp_generation {
 
     /// Ensures that `new_from_n` is available for types implementing [`Into<Z>`].
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn availability() {
         let _ = RingLPR::new_from_n(16u8);
         let _ = RingLPR::new_from_n(16u16);

--- a/src/construction/signature.rs
+++ b/src/construction/signature.rs
@@ -11,9 +11,9 @@
 //! implementing the [`SignatureScheme`] trait.
 //!
 //! - \[1\] Gentry, Craig, Chris Peikert, and Vinod Vaikuntanathan.
-//! "Trapdoors for hard lattices and new cryptographic constructions."
-//! Proceedings of the fortieth annual ACM symposium on Theory of computing. 2008.
-//! <https://doi.org/10.1145/1374376.1374407>
+//!     "Trapdoors for hard lattices and new cryptographic constructions."
+//!     Proceedings of the fortieth annual ACM symposium on Theory of computing. 2008.
+//!     <https://doi.org/10.1145/1374376.1374407>
 
 mod fdh;
 mod pfdh;

--- a/src/construction/signature/fdh.rs
+++ b/src/construction/signature/fdh.rs
@@ -35,7 +35,7 @@ pub mod serialize;
 ///
 /// Attributes
 /// - `psf`: The PSF which has to implement the [`PSF`] trait and must also be
-/// (de-)serializable.
+///     (de-)serializable.
 /// - `storage`: A Hashmap that safes all previously signed messages and their signature
 /// - `hash`: The hash-function which has to map a string into the correct domain
 ///

--- a/src/construction/signature/fdh/gpv_ring.rs
+++ b/src/construction/signature/fdh/gpv_ring.rs
@@ -105,7 +105,7 @@ mod test_fdh {
     /// Ensure that the generated signature is valid.
     #[test]
     fn ensure_valid_signature_is_generated() {
-        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, compute_s());
         let (pk, sk) = fdh.gen();
 
         for i in 0..10 {
@@ -125,7 +125,7 @@ mod test_fdh {
     /// Ensure that an entry is actually added to the local storage.
     #[test]
     fn storage_filled() {
-        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, compute_s());
 
         let m = "Hello World!";
         let (pk, sk) = fdh.gen();
@@ -139,7 +139,7 @@ mod test_fdh {
     /// Ensure that after deserialization the HashMap still contains all entries.
     #[test]
     fn reload_hashmap() {
-        let mut fdh = FDH::init_gpv_ring(N, MODULUS, &compute_s());
+        let mut fdh = FDH::init_gpv_ring(N, MODULUS, compute_s());
 
         // fill one entry in the HashMap
         let m = "Hello World!";

--- a/src/construction/signature/pfdh.rs
+++ b/src/construction/signature/pfdh.rs
@@ -35,10 +35,10 @@ pub mod serialize;
 ///
 /// Attributes
 /// - `psf`: The PSF which has to implement the [`PSF`] trait and must also be
-/// (de-)serializable.
+///     (de-)serializable.
 /// - `hash`: The hash-function which has to map a string into the correct domain.
 /// - `randomness_length`: The length of the salt that is added to the string before
-/// hashing.
+///     hashing.
 ///
 /// # Example
 /// ## Signature Scheme from [`PSFGPV`](crate::primitive::psf::PSFGPV)

--- a/src/primitive/psf.rs
+++ b/src/primitive/psf.rs
@@ -12,14 +12,14 @@
 //! The main references are listed in the following
 //! and will be further referenced in submodules by these numbers:
 //! - \[1\] Micciancio, D., Peikert, C. (2012).
-//! Trapdoors for Lattices: Simpler, Tighter, Faster, Smaller.
-//! In: Pointcheval, D., Johansson, T. (eds) Advances in Cryptology – EUROCRYPT 2012.
-//! EUROCRYPT 2012. Lecture Notes in Computer Science, vol 7237.
-//! Springer, Berlin, Heidelberg. <https://doi.org/10.1007/978-3-642-29011-4_41>
+//!     Trapdoors for Lattices: Simpler, Tighter, Faster, Smaller.
+//!     In: Pointcheval, D., Johansson, T. (eds) Advances in Cryptology – EUROCRYPT 2012.
+//!     EUROCRYPT 2012. Lecture Notes in Computer Science, vol 7237.
+//!     Springer, Berlin, Heidelberg. <https://doi.org/10.1007/978-3-642-29011-4_41>
 //! - \[2\] Gür, K.D., Polyakov, Y., Rohloff, K., Ryan, G.W. and Savas, E., 2018,
-//! January. Implementation and evaluation of improved Gaussian sampling for lattice
-//!  trapdoors. In Proceedings of the 6th Workshop on Encrypted Computing & Applied
-//! Homomorphic Cryptography (pp. 61-71). <https://dl.acm.org/doi/pdf/10.1145/3267973.3267975>
+//!     January. Implementation and evaluation of improved Gaussian sampling for lattice
+//!     trapdoors. In Proceedings of the 6th Workshop on Encrypted Computing & Applied
+//!     Homomorphic Cryptography (pp. 61-71). <https://dl.acm.org/doi/pdf/10.1145/3267973.3267975>
 
 mod gpv;
 mod gpv_ring;

--- a/src/sample/g_trapdoor.rs
+++ b/src/sample/g_trapdoor.rs
@@ -14,25 +14,25 @@
 //! The main references are listed in the following
 //! and will be further referenced in submodules by these numbers:
 //! - \[1\] Micciancio, D., Peikert, C. (2012).
-//! Trapdoors for Lattices: Simpler, Tighter, Faster, Smaller.
-//! In: Pointcheval, D., Johansson, T. (eds) Advances in Cryptology – EUROCRYPT 2012.
-//! EUROCRYPT 2012. Lecture Notes in Computer Science, vol 7237.
-//! Springer, Berlin, Heidelberg. <https://doi.org/10.1007/978-3-642-29011-4_41>
+//!     Trapdoors for Lattices: Simpler, Tighter, Faster, Smaller.
+//!     In: Pointcheval, D., Johansson, T. (eds) Advances in Cryptology – EUROCRYPT 2012.
+//!     EUROCRYPT 2012. Lecture Notes in Computer Science, vol 7237.
+//!     Springer, Berlin, Heidelberg. <https://doi.org/10.1007/978-3-642-29011-4_41>
 //! - \[2\] El Bansarkhani, R., Buchmann, J. (2014). Improvement and Efficient
-//! Implementation of a Lattice-Based Signature Scheme. In: Lange, T., Lauter, K.,
-//! Lisoněk, P. (eds) Selected Areas in Cryptography -- SAC 2013. SAC 2013. Lecture Notes
-//! in Computer Science(), vol 8282. Springer, Berlin, Heidelberg.
-//! <https://doi.org/10.1007/978-3-662-43414-7_3>
+//!     Implementation of a Lattice-Based Signature Scheme. In: Lange, T., Lauter, K.,
+//!     Lisoněk, P. (eds) Selected Areas in Cryptography -- SAC 2013. SAC 2013. Lecture Notes
+//!     in Computer Science(), vol 8282. Springer, Berlin, Heidelberg.
+//!     <https://doi.org/10.1007/978-3-662-43414-7_3>
 //! - \[3\] Gür, K.D., Polyakov, Y., Rohloff, K., Ryan, G.W. and Savas, E., 2018,
-//! January. Implementation and evaluation of improved Gaussian sampling for lattice
-//!  trapdoors. In Proceedings of the 6th Workshop on Encrypted Computing & Applied
-//! Homomorphic Cryptography (pp. 61-71). <https://dl.acm.org/doi/pdf/10.1145/3267973.3267975>
+//!     January. Implementation and evaluation of improved Gaussian sampling for lattice
+//!     trapdoors. In Proceedings of the 6th Workshop on Encrypted Computing & Applied
+//!     Homomorphic Cryptography (pp. 61-71). <https://dl.acm.org/doi/pdf/10.1145/3267973.3267975>
 //! - \[4\] Cash, D., Hofheinz, D., Kiltz, E., & Peikert, C. (2012).
-//! Bonsai trees, or how to delegate a lattice basis. Journal of cryptology, 25, 601-639.
-//! <https://doi.org/10.1007/s00145-011-9105-2>
+//!     Bonsai trees, or how to delegate a lattice basis. Journal of cryptology, 25, 601-639.
+//!     <https://doi.org/10.1007/s00145-011-9105-2>
 //! - \[5\] Chen, Yuanmi, and Phong Q. Nguyen. "BKZ 2.0: Better lattice security
-//! estimates." International Conference on the Theory and Application of Cryptology and
-//! Information Security. Berlin, Heidelberg: Springer Berlin Heidelberg, 2011.
+//!     estimates." International Conference on the Theory and Application of Cryptology and
+//!     Information Security. Berlin, Heidelberg: Springer Berlin Heidelberg, 2011.
 
 pub mod gadget_classical;
 pub mod gadget_parameters;

--- a/src/sample/g_trapdoor/gadget_classical.rs
+++ b/src/sample/g_trapdoor/gadget_classical.rs
@@ -22,7 +22,7 @@ use std::fmt::Display;
 /// - Generates the gadget matrix: `G`
 /// - Samples the trapdoor `R` from the specified distribution in `params`
 /// - Outputs `([a_bar | tag * g - a_bar * r], r)` as a tuple of `(A,R)`,
-/// where `R` defines a trapdoor for `A`.
+///     where `R` defines a trapdoor for `A`.
 ///
 /// Parameters:
 /// - `params`: all gadget parameters which are required to generate the trapdoor
@@ -46,9 +46,9 @@ use std::fmt::Display;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-/// if the matrices can not be concatenated due to mismatching dimensions.
+///     if the matrices can not be concatenated due to mismatching dimensions.
 /// - Returns a [`MathError`] of type [`MismatchingModulus`](MathError::MismatchingModulus)
-/// if the matrices can not be concatenated due to mismatching moduli.
+///     if the matrices can not be concatenated due to mismatching moduli.
 ///
 /// # Panics ...
 /// - if `params.k < 1` or it does not fit into an [`i64`].

--- a/src/sample/g_trapdoor/gadget_parameters.rs
+++ b/src/sample/g_trapdoor/gadget_parameters.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// - `n`: the security parameter
 /// - `k`: the size of the gadget vector: mostly taken as `log_base(q)`
 /// - `m_bar`: has to be chose appropriately for regularity and for
-/// the distribution to be sub-Gaussian
+///     the distribution to be sub-Gaussian
 /// - `base`: the base with which the gadget-vector and matrix are generated
 /// - `q`: the modulus
 /// - `distribution`: the distribution from which the matrix `A_bar` is sampled
@@ -59,7 +59,7 @@ pub struct GadgetParameters {
 /// - `n`: the security parameter
 /// - `k`: the size of the gadget vector: mostly taken as `log_base(q)`
 /// - `m_bar`: has to be chose appropriately for regularity and for
-/// the distribution to be sub-Gaussian
+///     the distribution to be sub-Gaussian
 /// - `base`: the base with which the gadget-vector and matrix are generated
 /// - `q`: the modulus
 /// - `modulus`: the polynomial that is used for reduction
@@ -88,13 +88,13 @@ impl GadgetParameters {
     ///
     /// - `base = 2` is taken from [\[1\]](<../index.html#:~:text=[1]>): Theorem 1.
     /// - `k = log_2_ceil(q)` is taken from [\[1\]](<../index.html#:~:text=[1]>):
-    /// Theorem 1.
+    ///     Theorem 1.
     /// - `w = n * k`: As it is required to match the dimension of the gadget matrix,
-    /// hence it has to  equal to `n * size of gadget_vec`
+    ///     hence it has to  equal to `n * size of gadget_vec`
     /// - `m_bar = n * k + log(n)^2`: is taken from [\[1\]](<../index.html#:~:text=[1]>)
-    /// as a function satisfying `m_bar = n log q + ω(log n)`
+    ///     as a function satisfying `m_bar = n log q + ω(log n)`
     /// - the distribution is taken as [`PlusMinusOneZero`],
-    /// see the example from [\[1\]](<../index.html#:~:text=[1]>): after statistical instantiation in section 3.2
+    ///     see the example from [\[1\]](<../index.html#:~:text=[1]>): after statistical instantiation in section 3.2
     ///
     /// Parameters:
     /// - `n`: the security parameter for the generation
@@ -142,10 +142,10 @@ impl GadgetParametersRing {
     ///
     /// - `base = 2` is taken from [\[3\]](<../index.html#:~:text=[3]>)
     /// - `k = log_2_ceil(q)` is taken from [\[3\]](<../index.html#:~:text=[3]>):
-    /// Algorithm 1.
+    ///     Algorithm 1.
     /// - `m_bar = 2 + k`: is taken from [\[3\]](<../index.html#:~:text=[3]>)
     /// - the distribution is taken as [`SampleZ`],
-    /// as in [\[3\]](<../index.html#:~:text=[3]>)
+    ///     as in [\[3\]](<../index.html#:~:text=[3]>)
     /// - the modulus is defined by `X^n +1 mod q` as in [\[3\]](<../index.html#:~:text=[3]>)
     ///
     /// Parameters:

--- a/src/sample/g_trapdoor/gadget_ring.rs
+++ b/src/sample/g_trapdoor/gadget_ring.rs
@@ -24,8 +24,8 @@ use std::fmt::Display;
 /// - Generates the gadget matrix: `G`
 /// - Samples the trapdoor `R` from the specified distribution in `params`
 /// - Outputs
-/// `([1 | a_bar | g_1 - (a_bar * r_1 + e_1) | ... | g_k - (a_bar * r_k + e_k) ], r, e)`
-/// as a tuple of `(A,R)`, where `R` defines a trapdoor for `A`.
+///     `([1 | a_bar | g_1 - (a_bar * r_1 + e_1) | ... | g_k - (a_bar * r_k + e_k) ], r, e)`
+///     as a tuple of `(A,R)`, where `R` defines a trapdoor for `A`.
 ///
 /// Parameters:
 /// - `params`: all gadget parameters which are required to generate the trapdoor
@@ -49,9 +49,9 @@ use std::fmt::Display;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`MismatchingMatrixDimension`](MathError::MismatchingMatrixDimension)
-/// if the matrices can not be concatenated due to mismatching dimensions.
+///     if the matrices can not be concatenated due to mismatching dimensions.
 /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds)
-/// if row or column are greater than the matrix size.
+///     if row or column are greater than the matrix size.
 ///
 /// # Panics ...
 /// - if `params.k < 1` or it does not fit into an [`i64`].

--- a/src/sample/g_trapdoor/short_basis_ring.rs
+++ b/src/sample/g_trapdoor/short_basis_ring.rs
@@ -28,10 +28,10 @@ use qfall_math::{
 /// - `W' := [X^0 | X^1 | ... | X^{n-1}] ⊗ W`,
 /// - `I_2' := [X^0 | X^1 | ... | X^{n-1}] ⊗ I_2` and
 /// - `S':= [X^0 | X^1 | ... | X^{n-1}] ⊗ S`.
-/// Here `W` is a solution of `g^t W = -A [ I_2 | 0 ] mod q`,
-/// `S` is a reordered (if `base^k=q` then reversed, otherwise the same as before)
-/// short base of `Λ^⟂(g^t)`, i.e. `S''` is a reordered short base of `g^t`
-/// in the classical case and `S':= [X^0 | X^1 | ... | X^{n-1}] ⊗ S''`.
+///     Here `W` is a solution of `g^t W = -A [ I_2 | 0 ] mod q`,
+///     `S` is a reordered (if `base^k=q` then reversed, otherwise the same as before)
+///     short base of `Λ^⟂(g^t)`, i.e. `S''` is a reordered short base of `g^t`
+///     in the classical case and `S':= [X^0 | X^1 | ... | X^{n-1}] ⊗ S''`.
 ///
 /// The appropriate reordering comes from
 /// [\[1\]](<../index.html#:~:text=[1]>) and Lemma 3.2 from

--- a/src/utils/common_moduli.rs
+++ b/src/utils/common_moduli.rs
@@ -34,7 +34,7 @@ use std::fmt::Display;
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-/// the `n` is negative or it does not fit into an [`i64`].
+///     the `n` is negative or it does not fit into an [`i64`].
 ///
 /// # Panics ...
 /// - if the `modulus` is not larger than `1`.
@@ -65,7 +65,7 @@ pub fn new_anticyclic(
 ///
 /// # Errors and Failures
 /// - Returns a [`MathError`] of type [`OutOfBounds`](MathError::OutOfBounds) if
-/// the `n` is negative or it does not fit into an [`i64`].
+///     the `n` is negative or it does not fit into an [`i64`].
 ///
 /// # Panics ...
 /// - if the `modulus` is not larger than `1`.


### PR DESCRIPTION
**Description**

<!-- 
Please include a summary of the changes and which issue is fixed or which feature it added.
Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR corrects newly marked warnings by clippy that were introduced by recent updates of clippy.
- [x] lists in doc comments where not indented correctly when linebreaks occur. The respective check in clippy was introduced in patch 1.80.0 (March 30th 2024) https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation
- [x] fix clippy errors in tests that were not marked before (generic_args -> resulting from availability of Into<Modulus>)


<!--
If Connected to an issue, include:
Closes #(issue number)
-->

**Testing**

<!-- Please shortly describe how you tested your code and mark all you have done after -->

<!-- exclude any of the following if they do not apply -->
- [x] The documentation does not change a lot as the previous formulation passed the same way, but was simply flagged by clippy. (But now the doc-comments in the code are better to read)
<!-- Please add other tests if any other have been performed -->

**Checklist:**

<!-- This is a short summary of the things the programmer should always consider before merging-->

- [x] I have performed a self-review of my own code
  - [x] The doc comments fit our style guide
