### PR TITLE
Avoid zip issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qfall-tools"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85" # due to rand and rand_distr dependency
+rust-version = "1.87" # due to wit_bindgen dependency
 description = "Common sub-modules and procedures in lattice-based constructions"
 readme = "README.md"
 homepage = "https://qfall.github.io"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This `tools`-crate collects common sub-modules and features used by lattice-base
 
 ## Quick-Start
 First, ensure that you use a Unix-like distribution (Linux or MacOS). Setup [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) if you're using Windows. This is required due to this crate's dependency on FLINT.
-Then, make sure your `rustc --version` is `1.85` or newer. 
+Then, make sure your `rustc --version` is `1.87` or newer. 
 
 Furthermore, it's required that `m4`, a C-compiler such as `gcc`, and `make` are installed.
 ```bash

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,5 +1,5 @@
 <!---
-Copyright © 2023 Sven Moog
+Copyright 2023 Sven Moog
 
 This file is part of qFALL-tools.
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Sven Moog
+// Copyright 2023 Sven Moog
 //
 // This file is part of qFALL-tools.
 //

--- a/benches/psf.rs
+++ b/benches/psf.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/benches/psf.rs
+++ b/benches/psf.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/compression/lossy_compression_fips203.rs
+++ b/src/compression/lossy_compression_fips203.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/compression/lossy_compression_fips203.rs
+++ b/src/compression/lossy_compression_fips203.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer, Marvin Beckmann
+// Copyright 2023 Niklas Siemer, Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer, Marvin Beckmann
+// Copyright 2023 Jan Niklas Siemer, Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive/psf.rs
+++ b/src/primitive/psf.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marcel Luca Schmidt, Marvin Beckmann
+// Copyright 2023 Marcel Luca Schmidt, Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive/psf/gpv.rs
+++ b/src/primitive/psf/gpv.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive/psf/gpv_ring.rs
+++ b/src/primitive/psf/gpv_ring.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive/psf/mp_perturbation.rs
+++ b/src/primitive/psf/mp_perturbation.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/primitive/psf/mp_perturbation.rs
+++ b/src/primitive/psf/mp_perturbation.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor.rs
+++ b/src/sample/g_trapdoor.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/gadget_classical.rs
+++ b/src/sample/g_trapdoor/gadget_classical.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/gadget_default.rs
+++ b/src/sample/g_trapdoor/gadget_default.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/gadget_parameters.rs
+++ b/src/sample/g_trapdoor/gadget_parameters.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/gadget_ring.rs
+++ b/src/sample/g_trapdoor/gadget_ring.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/short_basis_classical.rs
+++ b/src/sample/g_trapdoor/short_basis_classical.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/short_basis_ring.rs
+++ b/src/sample/g_trapdoor/short_basis_ring.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/sample/g_trapdoor/trapdoor_distribution.rs
+++ b/src/sample/g_trapdoor/trapdoor_distribution.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils/common_encodings.rs
+++ b/src/utils/common_encodings.rs
@@ -1,4 +1,4 @@
-// Copyright © 2025 Niklas Siemer
+// Copyright 2025 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils/common_encodings.rs
+++ b/src/utils/common_encodings.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Niklas Siemer
+// Copyright 2025 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils/common_moduli.rs
+++ b/src/utils/common_moduli.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Niklas Siemer
+// Copyright 2023 Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils/common_moduli.rs
+++ b/src/utils/common_moduli.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Niklas Siemer
+// Copyright 2023 Jan Niklas Siemer
 //
 // This file is part of qFALL-tools.
 //

--- a/src/utils/rotation_matrix.rs
+++ b/src/utils/rotation_matrix.rs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Marvin Beckmann
+// Copyright 2023 Marvin Beckmann
 //
 // This file is part of qFALL-tools.
 //


### PR DESCRIPTION
**Description**

This PR resolves problems encountered when converting to .zip format. For some reason, the unicode symbol for copyright was a problem.

Furthermore, it updates the required Rust version to 1.87.